### PR TITLE
Fix layout for label

### DIFF
--- a/src/__tests__/components/BoardNameForm.test.tsx
+++ b/src/__tests__/components/BoardNameForm.test.tsx
@@ -27,7 +27,7 @@ describe('BoardNameForm component', () => {
       store,
     );
 
-    const boardNameForm = getByTestId('boardNameForm') as HTMLInputElement;
+    const boardNameForm = getByTestId('flexTextField') as HTMLInputElement;
     const inputBoardName = 'update';
     fireEvent.change(boardNameForm, { target: { value: inputBoardName } });
 
@@ -44,7 +44,7 @@ describe('BoardNameForm component', () => {
       store,
     );
 
-    const boardNameForm = getByTestId('boardNameForm') as HTMLInputElement;
+    const boardNameForm = getByTestId('flexTextField') as HTMLInputElement;
     const inputBoardName = '';
     fireEvent.change(boardNameForm, { target: { value: inputBoardName } });
     fireEvent.blur(boardNameForm);
@@ -69,7 +69,7 @@ describe('BoardNameForm component', () => {
       ['/board/1'],
     );
 
-    const boardNameForm = getByTestId('boardNameForm') as HTMLInputElement;
+    const boardNameForm = getByTestId('flexTextField') as HTMLInputElement;
     const inputBoardName = 'sample';
     fireEvent.change(boardNameForm, { target: { value: inputBoardName } });
     fireEvent.blur(boardNameForm);
@@ -95,7 +95,7 @@ describe('BoardNameForm component', () => {
       [`/board/${boardId}`],
     );
 
-    const boardNameForm = getByTestId('boardNameForm') as HTMLInputElement;
+    const boardNameForm = getByTestId('flexTextField') as HTMLInputElement;
     const inputBoardName = 'updated board';
     fireEvent.change(boardNameForm, { target: { value: inputBoardName } });
     fireEvent.blur(boardNameForm);

--- a/src/__tests__/components/CardLabel.test.tsx
+++ b/src/__tests__/components/CardLabel.test.tsx
@@ -1,0 +1,34 @@
+import React from 'react';
+
+import { render, storeFactory, fireEvent } from '../../testUtils';
+import { mockCard, mockLabels } from '../../utils/mockData';
+import { Store } from '../../store';
+import { CardLabel } from '../../components/CardLabel';
+import { CardContext } from '../../components/CardIndexContainer';
+
+describe('CardLabel component', () => {
+  let store: Store;
+  let detachLabel: jest.Mock;
+
+  beforeEach(() => {
+    store = storeFactory();
+    detachLabel = jest.fn();
+  });
+
+  test('should call `detachLabel` when click a component', () => {
+    const mockLabel = { id: 10 };
+    const { getByTestId } = render(
+      <CardContext.Provider value={mockCard}>
+        <CardLabel labels={mockLabels} label={mockLabel} detachLabel={detachLabel} />
+      </CardContext.Provider>,
+      store,
+    );
+
+    fireEvent.click(getByTestId('cardLabel'));
+    expect(detachLabel).toHaveBeenCalledWith({
+      cardId: mockCard.id,
+      labelId: mockLabel.id,
+      listId: mockCard.listId,
+    });
+  });
+});

--- a/src/__tests__/components/CardLabelForm.test.tsx
+++ b/src/__tests__/components/CardLabelForm.test.tsx
@@ -6,6 +6,7 @@ import { Store } from '../../store';
 import CardLabelForm from '../../components/CardLabelForm';
 
 describe('CardLabelForm component', () => {
+  const position = { top: 0, left: 0 };
   let store: Store;
   let closeCardLabelForm: jest.Mock;
 
@@ -16,7 +17,7 @@ describe('CardLabelForm component', () => {
 
   test('should call `closeCardLabelForm` when clicked a close button', () => {
     const { getByTestId } = render(
-      <CardLabelForm closeCardLabelForm={closeCardLabelForm} />,
+      <CardLabelForm closeCardLabelForm={closeCardLabelForm} position={position} />,
       store,
     );
 

--- a/src/__tests__/components/FlexTextArea.test.tsx
+++ b/src/__tests__/components/FlexTextArea.test.tsx
@@ -15,7 +15,7 @@ describe('FlexTextArea component', () => {
     onChange = jest.fn();
   });
 
-  test('should call `onChnage` when user input text', () => {
+  test('should call `onChange` when user input text', () => {
     const { getByRole } = render(<FlexTextArea value={value} onChange={onChange} />, store);
     const textarea = getByRole('textbox') as HTMLTextAreaElement;
     const mockText = 'some text';

--- a/src/__tests__/components/FlexTextField.test.tsx
+++ b/src/__tests__/components/FlexTextField.test.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+import userEvent from '@testing-library/user-event';
+
+import { render, storeFactory, fireEvent } from '../../testUtils';
+import { Store } from '../../store';
+import FlexTextField from '../../components/FlexTextField';
+
+describe('FlexTextField component', () => {
+  let store: Store;
+  let onChange: jest.Mock;
+  let value: string = '';
+  let onBlur: jest.Mock;
+
+  beforeEach(() => {
+    store = storeFactory();
+    onChange = jest.fn();
+    onBlur = jest.fn();
+  });
+
+  test('should call `onChange` when user input text', () => {
+    const { getByRole } = render(<FlexTextField value={value} onChange={onChange} />, store);
+    const textField = getByRole('textbox') as HTMLInputElement;
+    const mockText = 'some text';
+    userEvent.type(textField, mockText);
+
+    expect(onChange).toHaveBeenCalledTimes(mockText.length);
+  });
+
+  test('textfield value is equal to dummy HTMLElement value', () => {
+    value = 'some text';
+    const { getByRole, getByTestId } = render(
+      <FlexTextField value={value} onChange={onChange} />,
+      store,
+    );
+    const textField = getByRole('textbox') as HTMLInputElement;
+
+    expect(textField.value).toBe(value);
+    expect(getByTestId('dummyTextField')).toHaveTextContent(value);
+  });
+
+  test('should call `onBlur` when focus out from a text field', () => {
+    const { getByRole } = render(
+      <FlexTextField autoFocus onBlur={onBlur} value={value} onChange={onChange} />,
+      store,
+    );
+    const textField = getByRole('textbox') as HTMLInputElement;
+    fireEvent.blur(textField);
+
+    expect(onBlur).toHaveBeenCalled();
+  });
+
+  test('should focus on a text field if props of `autoFocus` is true', () => {
+    const { getByRole } = render(
+      <FlexTextField autoFocus onBlur={onBlur} value={value} onChange={onChange} />,
+      store,
+    );
+    const textField = getByRole('textbox') as HTMLInputElement;
+    expect(textField).toHaveFocus();
+  });
+
+  test('should not focus on a text field if props of `autoFocus` is false', () => {
+    const { getByRole } = render(
+      <FlexTextField onBlur={onBlur} value={value} onChange={onChange} />,
+      store,
+    );
+    const textField = getByRole('textbox') as HTMLInputElement;
+    expect(textField).not.toHaveFocus();
+  });
+});

--- a/src/__tests__/components/Header.test.tsx
+++ b/src/__tests__/components/Header.test.tsx
@@ -7,7 +7,12 @@ import { Store } from '../../store';
 
 describe('Header component', () => {
   let mockLocation: {pathname: string};
-  const renderWithRouter = (component: ReactElement, store: Store) => (
+  let store: Store;
+  beforeEach(() => {
+    store = storeFactory();
+  });
+
+  const renderWithRouter = (component: ReactElement) => (
     render(
       <MemoryRouter>
         {component}
@@ -24,11 +29,22 @@ describe('Header component', () => {
   );
 
   test('navigate to `/` when click a home icon', () => {
-    const store = storeFactory();
-    const { getByTestId } = renderWithRouter(<Header />, store);
+    const { getByTestId } = renderWithRouter(<Header />);
 
     fireEvent.click(getByTestId('homeIcon'));
 
     expect(mockLocation.pathname).toBe('/');
+  });
+
+  test('should show `LabelEdit` if state of `isLabelEditVisible` is true', () => {
+    const { getByTestId } = renderWithRouter(<Header />);
+    fireEvent.click(getByTestId('openLabelEditButton'));
+
+    expect(getByTestId('labelEdit')).toBeVisible();
+  });
+
+  test('should hide `LabelEdit` if state of `isLabelEditVisible` is false', () => {
+    const { queryByTestId } = renderWithRouter(<Header />);
+    expect(queryByTestId('labelEdit')).toBeNull();
   });
 });

--- a/src/__tests__/components/LabelIndex.test.tsx
+++ b/src/__tests__/components/LabelIndex.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { Route } from 'react-router-dom';
 
-import { renderWithRouter, fireEvent, storeFactory } from '../../testUtils';
+import { renderWithRouter, storeFactory } from '../../testUtils';
 import { Store } from '../../store';
 import { mockLabels } from '../../utils/mockData';
 import { LabelIndex } from '../../components/LabelIndex';
@@ -13,24 +13,6 @@ describe('LabelIndex component', () => {
   beforeEach(() => {
     store = storeFactory();
     fetchAllLabel = jest.fn();
-  });
-
-  test('should show `LabelEdit` if state of `isLabelEditVisible` is true', () => {
-    const { getByTestId } = renderWithRouter(
-      <LabelIndex fetchAllLabel={fetchAllLabel} labels={mockLabels} />,
-      store,
-    );
-    fireEvent.click(getByTestId('addLabelButton'));
-
-    expect(getByTestId('labelEdit')).toBeVisible();
-  });
-
-  test('should hide `LabelEdit` if state of `isLabelEditVisible` is false', () => {
-    const { queryByTestId } = renderWithRouter(
-      <LabelIndex fetchAllLabel={fetchAllLabel} labels={mockLabels} />,
-      store,
-    );
-    expect(queryByTestId('labelEdit')).toBeNull();
   });
 
   test('should call `fetchAllLabel` when component did mount', () => {

--- a/src/__tests__/components/ToolBar.test.tsx
+++ b/src/__tests__/components/ToolBar.test.tsx
@@ -22,7 +22,7 @@ describe('ToolBar component', () => {
     const { getByTestId } = renderWithRouter(<ToolBar boardName={boardName} />, store);
 
     fireEvent.click(getByTestId('boardName'));
-    const boardNameForm = getByTestId('boardNameForm') as HTMLInputElement;
+    const boardNameForm = getByTestId('flexTextField') as HTMLInputElement;
 
     expect(boardNameForm.value).toBe(boardName);
   });

--- a/src/components/BoardNameForm.tsx
+++ b/src/components/BoardNameForm.tsx
@@ -4,6 +4,7 @@ import { connect, ConnectedProps } from 'react-redux';
 import { useParams } from 'react-router-dom';
 
 import * as boardActions from '../store/board/actions';
+import FlexTextField from './FlexTextField';
 
 const mapDispatchToProps = {
   updateBoard: boardActions.updateBoard,
@@ -38,15 +39,11 @@ export const BoardNameForm = (props: BoardNameFormProps) => {
   };
 
   return (
-    <input
-      // eslint-disable-next-line jsx-a11y/no-autofocus
+    <FlexTextField
       autoFocus
-      data-testid="boardNameForm"
-      type="text"
       value={boardName}
       onChange={(event) => setBoardName(event.target.value)}
       onBlur={onBlur}
-      className="boardNameForm"
     />
   );
 };

--- a/src/components/CardLabel.tsx
+++ b/src/components/CardLabel.tsx
@@ -1,7 +1,9 @@
-import React from 'react';
+import React, { useContext } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
 
 import { RootState } from '../store';
+import * as cardActions from '../store/card/actions';
+import { CardContext } from './CardIndexContainer';
 
 const mapStateToProps = (state: RootState) => {
   const { label } = state;
@@ -10,7 +12,11 @@ const mapStateToProps = (state: RootState) => {
   };
 };
 
-const connector = connect(mapStateToProps);
+const mapDispatchToProps = {
+  detachLabel: cardActions.detachLabel,
+};
+
+const connector = connect(mapStateToProps, mapDispatchToProps);
 
 type PropsFromRedux = ConnectedProps<typeof connector>
 
@@ -19,12 +25,27 @@ type CardLabelProps = PropsFromRedux & {
 }
 
 const CardLabel = (props: CardLabelProps) => {
-  const { label, labels } = props;
+  const { label, labels, detachLabel } = props;
+
+  const card = useContext(CardContext);
 
   const targetLabel = labels.find((l) => l.id === label.id);
 
+  const onClickLabel = () => {
+    if (card) {
+      detachLabel({ cardId: card.id, listId: card.listId, labelId: label.id });
+    }
+  };
+
   return (
-    <div style={{ backgroundColor: targetLabel?.color }} className="cardLabel">
+    <div
+      role="button"
+      tabIndex={0}
+      onClick={onClickLabel}
+      onKeyPress={onClickLabel}
+      style={{ backgroundColor: targetLabel?.color }}
+      className="cardLabel"
+    >
       {targetLabel?.name}
     </div>
   );

--- a/src/components/CardLabel.tsx
+++ b/src/components/CardLabel.tsx
@@ -24,7 +24,7 @@ type CardLabelProps = PropsFromRedux & {
   label: { id: number }
 }
 
-const CardLabel = (props: CardLabelProps) => {
+export const CardLabel = (props: CardLabelProps) => {
   const { label, labels, detachLabel } = props;
 
   const card = useContext(CardContext);
@@ -39,6 +39,7 @@ const CardLabel = (props: CardLabelProps) => {
 
   return (
     <div
+      data-testid="cardLabel"
       role="button"
       tabIndex={0}
       onClick={onClickLabel}

--- a/src/components/CardLabelForm.tsx
+++ b/src/components/CardLabelForm.tsx
@@ -1,4 +1,10 @@
-import React from 'react';
+import React, {
+  useRef,
+  useEffect,
+  useState,
+  useCallback,
+} from 'react';
+
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { connect, ConnectedProps } from 'react-redux';
 
@@ -19,13 +25,38 @@ type PropsFromRedux = ConnectedProps<typeof connector>
 
 type CardLabelFormProps = PropsFromRedux & {
   closeCardLabelForm: () => void
+  position: { top: number, left: number }
 }
 
 export const CardLabelForm = (props: CardLabelFormProps) => {
-  const { labels, closeCardLabelForm } = props;
+  const { labels, closeCardLabelForm, position } = props;
+
+  const [elementHeight, setElementHeight] = useState({});
+
+  const ref = useRef<HTMLDivElement>(null);
+
+  const onResizeEnd = useCallback(() => {
+    if (!ref || !ref.current) {
+      return;
+    }
+    const { clientHeight } = ref.current;
+    const overflowElementY = window.innerHeight - (clientHeight + position.top);
+    setElementHeight({ maxHeight: clientHeight + overflowElementY });
+  }, [position.top]);
+
+  useEffect(() => {
+    window.addEventListener('resize', onResizeEnd);
+    return () => window.removeEventListener('resize', onResizeEnd);
+  }, [onResizeEnd]);
 
   return (
-    <div data-testid="cardLabelForm" className="cardLabelForm">
+    <div
+      id="cardLabelForm"
+      ref={ref}
+      data-testid="cardLabelForm"
+      style={{ ...position, ...elementHeight }}
+      className="cardLabelForm"
+    >
       <div className="cardLabelFormHeader">
         <div className="cardLabelFormHeader__text">{addLabelText}</div>
         <div

--- a/src/components/CardLabelFormButton.tsx
+++ b/src/components/CardLabelFormButton.tsx
@@ -3,12 +3,28 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import CardLabelForm from './CardLabelForm';
 
+const CARD_LABEL_FORM_WIDTH = 300;
+const CARD_LABEL_FORM_BUTTON_HEIGHT = 30;
+
 const CardLabelFormButton = () => {
   const [isCardLabelFormVisible, setCardLabelFormVisible] = useState(false);
+  const [position, setPosition] = useState({ top: 0, left: 0 });
 
   const closeCardLabelForm = useCallback(() => {
     setCardLabelFormVisible(false);
   }, []);
+
+  const onClickButton = (event: React.MouseEvent) => {
+    const { top, left } = event.currentTarget.getBoundingClientRect();
+    const clientRect = { top: top + CARD_LABEL_FORM_BUTTON_HEIGHT, left };
+    const overflowElementX = window.innerWidth - (left + CARD_LABEL_FORM_WIDTH);
+
+    if (overflowElementX < 0) {
+      clientRect.left = left + overflowElementX;
+    }
+    setPosition(clientRect);
+    setCardLabelFormVisible(true);
+  };
 
   return (
     <div className="cardLabelFormButtonWrapper">
@@ -16,14 +32,14 @@ const CardLabelFormButton = () => {
         data-testid="cardLabelFormButton"
         role="button"
         tabIndex={0}
-        onClick={() => setCardLabelFormVisible(true)}
+        onClick={onClickButton}
         onKeyPress={() => setCardLabelFormVisible(true)}
         className="cardLabelFormButton"
       >
         <FontAwesomeIcon icon={['fas', 'plus']} />
       </div>
       {isCardLabelFormVisible
-        && <CardLabelForm closeCardLabelForm={closeCardLabelForm} />}
+        && <CardLabelForm position={position} closeCardLabelForm={closeCardLabelForm} />}
     </div>
   );
 };

--- a/src/components/FlexTextField.tsx
+++ b/src/components/FlexTextField.tsx
@@ -1,0 +1,34 @@
+import React, { ChangeEvent } from 'react';
+
+type FlexTextFieldProps = {
+  value: string
+  onChange: (event: ChangeEvent<HTMLInputElement>) => void
+  autoFocus?: boolean
+  onBlur?: () => void
+}
+
+const FlexTextField = (props: FlexTextFieldProps) => {
+  const {
+    value,
+    onChange,
+    autoFocus,
+    onBlur,
+  } = props;
+
+  return (
+    <div className="flexTextField">
+      <div data-testid="dummyTextField" className="flexTextField__dummy">{value}</div>
+      <input
+        // eslint-disable-next-line jsx-a11y/no-autofocus
+        autoFocus={autoFocus}
+        type="text"
+        value={value}
+        onChange={onChange}
+        onBlur={onBlur}
+        className="flexTextField__textField"
+      />
+    </div>
+  );
+};
+
+export default FlexTextField;

--- a/src/components/FlexTextField.tsx
+++ b/src/components/FlexTextField.tsx
@@ -19,6 +19,7 @@ const FlexTextField = (props: FlexTextFieldProps) => {
     <div className="flexTextField">
       <div data-testid="dummyTextField" className="flexTextField__dummy">{value}</div>
       <input
+        data-testid="flexTextField"
         // eslint-disable-next-line jsx-a11y/no-autofocus
         autoFocus={autoFocus}
         type="text"

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -16,6 +16,7 @@ const Header = () => {
         </Link>
       </div>
       <div
+        data-testid="openLabelEditButton"
         role="button"
         tabIndex={0}
         onClick={() => setLabelEditVisible(true)}

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,15 +1,33 @@
-import React from 'react';
+import React, { useState } from 'react';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Link } from 'react-router-dom';
 
-const Header = () => (
-  <div className="header">
-    <div className="headerIcon">
-      <Link to="/" className="headerIcon__toIndex">
-        <FontAwesomeIcon icon={['fas', 'home']} data-testid="homeIcon" />
-      </Link>
+import LabelEdit from './LabelEdit';
+import { editLabelButtonText } from '../utils/text';
+
+const Header = () => {
+  const [isLabelEditVisible, setLabelEditVisible] = useState(false);
+
+  return (
+    <div className="header">
+      <div className="headerIcon">
+        <Link to="/" className="headerIcon__toIndex">
+          <FontAwesomeIcon icon={['fas', 'home']} data-testid="homeIcon" />
+        </Link>
+      </div>
+      <div
+        role="button"
+        tabIndex={0}
+        onClick={() => setLabelEditVisible(true)}
+        onKeyPress={() => setLabelEditVisible(true)}
+        className="openLabelEditButton"
+      >
+        <FontAwesomeIcon icon={['fas', 'pen']} />
+        <div className="openLabelEditButton__text">{editLabelButtonText}</div>
+      </div>
+      {isLabelEditVisible && <LabelEdit setLabelEditVisible={setLabelEditVisible} />}
     </div>
-  </div>
-);
+  );
+};
 
 export default Header;

--- a/src/components/LabelIndex.tsx
+++ b/src/components/LabelIndex.tsx
@@ -51,7 +51,7 @@ export const LabelIndex = (props: PropsFromRedux) => {
         onKeyPress={() => setLabelEditVisible(true)}
         className="addLabelButton"
       >
-        <FontAwesomeIcon icon={['fas', 'plus']} className="addLabelButton__icon" />
+        <FontAwesomeIcon icon={['fas', 'pen']} className="addLabelButton__icon" />
         <div className="addLabelButton__text">{editLabelButtonText}</div>
       </div>
       {isLabelEditVisible && <LabelEdit setLabelEditVisible={setLabelEditVisible} />}

--- a/src/components/LabelIndex.tsx
+++ b/src/components/LabelIndex.tsx
@@ -1,13 +1,10 @@
-import React, { useState, useEffect } from 'react';
+import React, { useEffect } from 'react';
 import { connect, ConnectedProps } from 'react-redux';
-import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { useParams } from 'react-router-dom';
 
 import { RootState } from '../store';
 import * as labelActions from '../store/label/actions';
 import Label from './Label';
-import LabelEdit from './LabelEdit';
-import { editLabelButtonText } from '../utils/text';
 
 const mapStateToProps = (state: RootState) => {
   const { label } = state;
@@ -27,7 +24,6 @@ type PropsFromRedux = ConnectedProps<typeof connector>
 export const LabelIndex = (props: PropsFromRedux) => {
   const { labels, fetchAllLabel } = props;
 
-  const [isLabelEditVisible, setLabelEditVisible] = useState(false);
   const { boardId } = useParams();
 
   useEffect(() => {
@@ -39,23 +35,9 @@ export const LabelIndex = (props: PropsFromRedux) => {
   }, []);
 
   return (
-    <>
-      <div className="labelContainer">
-        {labels.map((label) => <Label key={label.id} label={label} />)}
-      </div>
-      <div
-        data-testid="addLabelButton"
-        role="button"
-        tabIndex={0}
-        onClick={() => setLabelEditVisible(true)}
-        onKeyPress={() => setLabelEditVisible(true)}
-        className="addLabelButton"
-      >
-        <FontAwesomeIcon icon={['fas', 'pen']} className="addLabelButton__icon" />
-        <div className="addLabelButton__text">{editLabelButtonText}</div>
-      </div>
-      {isLabelEditVisible && <LabelEdit setLabelEditVisible={setLabelEditVisible} />}
-    </>
+    <div className="labelIndex">
+      {labels.map((label) => <Label key={label.id} label={label} />)}
+    </div>
   );
 };
 

--- a/src/css/Board.scss
+++ b/src/css/Board.scss
@@ -1,4 +1,6 @@
 .boardContainer {
+  display: flex;
+  flex-direction: column;
   height: calc(100vh - #{$header-height});
   width: 100%;
 }
@@ -7,10 +9,9 @@
   align-items: flex-start;
   box-sizing: border-box;
   display: flex;
-  height: calc(100vh - #{$header-height} - #{$toolbar-height} );
+  flex: 1;
   overflow-x: scroll;
   padding: 5px 20px 20px;
-  width: 100%;
   &::after {
     content: '';
     height: 1px;

--- a/src/css/BoardNameForm.scss
+++ b/src/css/BoardNameForm.scss
@@ -1,9 +1,0 @@
-.boardNameForm {
-  border-radius: 5px;
-  color: $font-color;
-  font-size: 1.1rem;
-  font-weight: bold;
-  margin-right: 20px;
-  outline-color: $pink;
-  padding: 2px 3px;
-}

--- a/src/css/CardLabelForm.scss
+++ b/src/css/CardLabelForm.scss
@@ -3,10 +3,10 @@
   border-radius: 3px;
   box-shadow: 0 2px 10px rgba(0, 0, 0, 0.4);
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
   padding: 10px 20px;
-  position: absolute;
-  top: 30px;
-  left: 0;
+  position: fixed;
   width: 300px;
   z-index: 15;
 }
@@ -26,4 +26,10 @@
 }
 
 .cardLabelFormList {
+  flex: 1;
+  overflow-y: scroll;
+  -ms-overflow-style: none;
+  &::-webkit-scrollbar {
+    display: none;
+  }
 }

--- a/src/css/FlexTextField.scss
+++ b/src/css/FlexTextField.scss
@@ -1,0 +1,37 @@
+.flexTextField {
+  display: flex;
+  font-size: 1.1rem;
+  font-weight: bold;
+  margin-bottom: 5px;
+  margin-right: 20px;
+  max-width: 100%;
+  position: relative;
+  &__dummy {
+    background-color: red;;
+    border: 1px solid;
+    border-radius: 5px;
+    box-sizing: border-box;
+    font: inherit;
+    line-height: 1.2rem;
+    max-width: 100%;
+    overflow: hidden;
+    padding: 5px;
+    visibility: hidden;
+    white-space: pre;
+  }
+  &__textField {
+    border: solid 1px $border-color;
+    border-radius: 5px;
+    box-sizing: border-box;
+    color: $font-color;
+    font: inherit;
+    height: 100%;
+    line-height: 1.2rem;
+    outline-color: $pink;
+    padding: 5px;
+    position: absolute;
+    top: 0;
+    left: 0;
+    width: 100%;
+  }
+}

--- a/src/css/Header.scss
+++ b/src/css/Header.scss
@@ -1,6 +1,8 @@
 .header {
   background-color: #ccc;
   box-sizing: border-box;
+  display: flex;
+  justify-content: space-between;
   height: $header-height;
   padding: 0 20px;
   width: 100%;
@@ -15,8 +17,32 @@
   &__toIndex {
     color: $font-color;
     font-size: 1.2rem;
+    position: relative;
     &:hover {
       color: $pink;
+      &::after {
+        @include hover-text();
+        content: 'ボード一覧に戻る';
+        position: absolute;
+        top: 30px;
+        left: 0;
+      }
     }
+  }
+}
+
+.openLabelEditButton {
+  align-items: center;
+  color: $font-color;
+  cursor: pointer;
+  display: flex;
+  font-size: 0.8rem;
+  margin: 3px 0;
+  text-decoration: underline;
+  &:hover {
+    color: $pink;
+  }
+  &__text {
+    margin-left: 3px;
   }
 }

--- a/src/css/Label.scss
+++ b/src/css/Label.scss
@@ -2,24 +2,22 @@
   cursor: pointer;
   margin-right: 10px;
   position: relative;
+  margin-bottom: 3px;
   &__icon {
     border-radius: 50%;
-    height: 100%;
-    width: calc(#{$toolbar-height} * 0.7);
+    height: 30px;
+    width: 30px;
   }
   &__name {
-    background-color: rgba(0, 0, 0, 0.8);
-    border-radius: 3px;
-    color: white;
-    font-size: 0.8rem;
-    padding: 2px 4px;
+    @include hover-text();
+    max-width: 300px;
+    overflow: hidden;
     position: absolute;
-    top: calc(#{$toolbar-height} * 0.75);
+    top: 35px;
     left: 50%;
+    text-overflow: ellipsis;
     transform: translateX(-50%);
     -webkit-transform: translateX(-50%);
     -ms-transform: translateX(-50%);
-    white-space: nowrap;
-    width: fit-content;
   }
 }

--- a/src/css/LabelEdit.scss
+++ b/src/css/LabelEdit.scss
@@ -10,6 +10,7 @@
   top: 0;
   right: 0;
   width: 400px;
+  z-index: 10;
   &-appear {
     right: -400px;
     &-active {

--- a/src/css/LabelEdit.scss
+++ b/src/css/LabelEdit.scss
@@ -2,6 +2,7 @@
   background-color: white;
   box-sizing: border-box;
   box-shadow: $box-shadow;
+  color: $font-color;
   display: flex;
   flex-direction: column;
   height: 100vh;

--- a/src/css/LabelEditRow.scss
+++ b/src/css/LabelEditRow.scss
@@ -1,7 +1,7 @@
 .labelEditRow {
   align-items: center;
   display: flex;
-  height: 45px;
+  padding: 5px 0;
   &__icon {
     border-radius: 50%;
     cursor: pointer;
@@ -12,6 +12,7 @@
   }
   &__textField {
     @include text-field();
+    box-sizing: border-box;
     flex: 1;
   }
   &__delete {

--- a/src/css/LabelIndex.scss
+++ b/src/css/LabelIndex.scss
@@ -17,6 +17,9 @@
   &:hover {
     background-color: $hover-overlay;
   }
+  &__text {
+    font-size: 0.9rem;
+  }
   &__icon {
     margin-right: 5px;
   }

--- a/src/css/LabelIndex.scss
+++ b/src/css/LabelIndex.scss
@@ -1,26 +1,6 @@
-.labelContainer {
+.labelIndex {
   display: flex;
   flex: 1;
-  height: calc(#{$toolbar-height} * 0.7);
-  margin-right: 20px;
-}
-
-.addLabelButton {
-  align-items: center;
-  background-color: $overlay;
-  border-radius: 3px;
-  color: white;
-  cursor: pointer;
-  display: flex;
-  height: calc(#{$toolbar-height} * 0.7);
-  padding: 0 10px;
-  &:hover {
-    background-color: $hover-overlay;
-  }
-  &__text {
-    font-size: 0.9rem;
-  }
-  &__icon {
-    margin-right: 5px;
-  }
+  flex-wrap: wrap;
+  min-width: fit-content;
 }

--- a/src/css/ToolBar.scss
+++ b/src/css/ToolBar.scss
@@ -4,15 +4,18 @@
   color: $font-color;
   display: flex;
   flex-wrap: wrap;
-  padding: 5px 20px;
+  padding: 5px 20px 0;
   width: 100%;
   &__title {
+    border: solid 1px transparent;
     cursor: pointer;
     font-size: 1.1rem;
     font-weight: bold;
+    line-height: 1.2rem;
+    margin-bottom: 5px;
     margin-right: 20px;
     overflow: hidden;
-    padding: 5px 0;
+    padding: 5px;
     text-overflow: ellipsis;
     word-wrap: none;
     white-space: nowrap;

--- a/src/css/ToolBar.scss
+++ b/src/css/ToolBar.scss
@@ -3,13 +3,19 @@
   box-sizing: border-box;
   color: $font-color;
   display: flex;
-  height: $toolbar-height;
-  padding: 0 20px;
+  flex-wrap: wrap;
+  padding: 5px 20px;
+  width: 100%;
   &__title {
     cursor: pointer;
     font-size: 1.1rem;
     font-weight: bold;
     margin-right: 20px;
+    overflow: hidden;
+    padding: 5px 0;
+    text-overflow: ellipsis;
+    word-wrap: none;
+    white-space: nowrap;
     &:hover {
       color: $pink;
     }

--- a/src/css/_mixin.scss
+++ b/src/css/_mixin.scss
@@ -70,3 +70,15 @@
     background-color: $card-element-hover-background;
   }
 }
+
+@mixin hover-text() {
+  background-color: rgba(0, 0, 0, 0.8);
+  border-radius: 3px;
+  color: white;
+  font-size: 0.8rem;
+  line-height: 1rem;
+  padding: 2px 4px;
+  width: fit-content;
+  white-space: nowrap;
+  z-index: 10;
+}

--- a/src/css/_variables.scss
+++ b/src/css/_variables.scss
@@ -2,7 +2,6 @@
 $box-shadow: 0 1px 2px rgba(0, 0, 0, 0.2);
 $header-height: 30px;
 $list-width: 270px;
-$toolbar-height: 40px;
 $card-detail-width: 800px;
 
 // colors

--- a/src/index.scss
+++ b/src/index.scss
@@ -18,7 +18,6 @@ code {
 @import './css/Board';
 @import './css/BoardForm';
 @import './css/BoardIndex';
-@import './css/BoardNameForm';
 @import './css/ButtonCancel';
 @import './css/ButtonSubmit';
 @import './css/Card';
@@ -40,6 +39,7 @@ code {
 @import './css/ColorPicker';
 @import './css/Dialog';
 @import './css/FlexTextArea';
+@import './css/FlexTextField';
 @import './css/Header';
 @import './css/Label';
 @import './css/LabelEdit';

--- a/src/store/card/reducers.ts
+++ b/src/store/card/reducers.ts
@@ -54,9 +54,12 @@ const cardReducer = (cards: Card[], action: CardActionTypes) => {
       }
 
       const previousLabels = targetCard.labels ? targetCard.labels : [];
-      targetCard.labels = [...previousLabels, { id: action.payload.labelId }];
+      const newCard = {
+        ...targetCard,
+        labels: [...previousLabels, { id: action.payload.labelId }],
+      };
       return {
-        cards: cards.map((card) => (card.id === targetCard.id ? targetCard : card)),
+        cards: cards.map((card) => (card.id === newCard.id ? newCard : card)),
       };
     }
     case DETACH_LABEL: {
@@ -64,10 +67,13 @@ const cardReducer = (cards: Card[], action: CardActionTypes) => {
       if (targetCard === undefined) {
         return { cards };
       }
-      targetCard.labels = targetCard.labels.filter((label) => label.id !== action.payload.labelId);
+      const newCard = {
+        ...targetCard,
+        labels: targetCard.labels.filter((label) => label.id !== action.payload.labelId),
+      };
 
       return {
-        cards: cards.map((card) => (card.id === targetCard.id ? targetCard : card)),
+        cards: cards.map((card) => (card.id === newCard.id ? newCard : card)),
       };
     }
     default:


### PR DESCRIPTION
## What

UIの修正

- 「ラベルを編集」のコンポーネントをツールバーからヘッダーへ移動
- ラベル編集用のコンポーネントのスタックを修正
- ラベル一覧の行の高さを文字数に応じて可変に
- カードにラベルを追加するためのフォームの表示位置を固定、またウインドウからはみ出さないようにする
- カードにアタッチされたラベルをクリックしたときのアクションを追加
- ツールバーをレスポンシブに
- ボード名のテキストフィールドを文字数に応じて伸縮させる