### PR TITLE
add safe navigator for card.labels

### DIFF
--- a/src/components/card/Card.tsx
+++ b/src/components/card/Card.tsx
@@ -136,7 +136,7 @@ export const Card = (props: CardProps) => {
       return 1;
     }
 
-    const targetLabel = card.labels.find((label) => selectedLabelIds.includes(label.id));
+    const targetLabel = card.labels?.find((label) => selectedLabelIds.includes(label.id));
     if (targetLabel) {
       return 1;
     }


### PR DESCRIPTION
## What

`card.labels`がNullの場合、ラベルで絞り込みを行うとクラッシュする問題を修正